### PR TITLE
build(release): bump version to 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2025-06-30
+### Fixed
+- Cambiando bookingPersons null por 0
+### Changed
+- Cambiando update a none para ddl-auto
+### Docs
+- update dependency versions and documentation
+
 ## [Unreleased]
 
 ## [0.0.1-SNAPSHOT] - 2025-06-16

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.import.service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2</version>
     <name>eterea.import.service</name>
     <description>Eterea Migration</description>
     <properties>


### PR DESCRIPTION
## Descripción
Este Pull Request actualiza la versión del proyecto a `0.0.2` y documenta los cambios recientes en el `CHANGELOG.md`. También incluye una actualización de la versión del `spring-boot-starter-parent`.

## Cambios Realizados
- [x] Actualización de la versión del proyecto en `pom.xml` de `0.0.1-SNAPSHOT` a `0.0.2`.
- [x] Actualización de la versión de `spring-boot-starter-parent` en `pom.xml` de `3.5.0` a `3.5.3`.
- [x] Actualización del `CHANGELOG.md` con los siguientes cambios:
    - Corrección: `Cambiando bookingPersons null por 0`
    - Cambio: `Cambiando update a none para ddl-auto`
    - Documentación: `update dependency versions and documentation`

## Impacto Potencial
- [ ] La actualización de la versión de Spring Boot Starter Parent podría introducir cambios menores en el comportamiento de las dependencias, aunque se espera que sean compatibles.

## Verificación
Para verificar los cambios, puedes:
1. `git checkout 21-actualización-de-versión-y-correcciones-menores`
2. Revisar los cambios en `pom.xml` y `CHANGELOG.md`.
3. Compilar el proyecto para asegurar que no hay errores: `mvn clean install`

## Notas Adicionales
Este PR cierra la issue #21.
