### PR TITLE
fix(ci): update deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create public directory
         run: mkdir -p public/diagrams
@@ -74,10 +74,10 @@ jobs:
         run: cp -r docs/diagrams/* public/diagrams/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updates checkout, upload-pages-artifact, and deploy-pages actions to resolve the build failure caused by the deprecation of artifact actions v3.