### PR TITLE
feat(wordpress): añade integracion con wordpress api rest para obtener ordenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Added
+- Nueva clase `WordPressApiClient` para comunicarse con REST API de Wordpress.
+- Nueva clase `WordPressClientConfig` para crear dos instancias de `WordPressApiClient` con configuración independiente desde `bootstrap.yml`.
+- Soporte para múltiples sitios WordPress simultáneamente.
+- Nuevo endpoint `GET /api/wordpress/capture/from-apis` para capturar órdenes desde APIs de WordPress con filtrado por rango de fechas.
+- Soporte para extracción de pagos desde "PlusPago" y "MacroClick" en order_notes.
+- Nuevo metodo `captureFromApi()` en `OrderNoteWebService` para capturar órdenes combinadas de ambos sitios.
+- Nuevo metodo `@Scheduled` llamado `captureFromApisLastTwelveHours()` para capturar órdenes de las últimas 12 horas cada 10 minutos.
+
+### Changed
+- Reemplazado `@RequiredArgsConstructor` por constructor explícito en `OrderNoteWebService` para inyección con `@Qualifier` de múltiples clientes WordPress.
+
 ## [2.0.0] - 2025-07-24
 ### Changed
 - Se reemplaza el descubrimiento de servicios de Eureka por Consul en la configuración (`bootstrap.yml`) y dependencias (`pom.xml`).
@@ -39,8 +52,6 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Refactorización de servicios para usar @RequiredArgsConstructor de Lombok en lugar de constructores @Autowired.
 
 > Fuente: análisis de `git diff HEAD`, `pom.xml` y cambios en `PaymentService.java` y `OrderNoteWebService.java`.
-
-## [Unreleased]
 
 ## [0.2.0] - 2025-07-12
 ### Added

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,41 @@
+# Etapa 1: Compilación con Maven y JDK
+# Usamos una imagen oficial que contiene Maven y Java (Temurin)
+FROM maven:3-eclipse-temurin-24-alpine AS build
+
+# Establecemos el directorio de trabajo
+WORKDIR /app
+
+# Copiamos solo el pom.xml para aprovechar la caché de Docker
+# Si las dependencias no cambian, esta capa no se reconstruye
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copiamos el resto del código fuente
+COPY src ./src
+
+# Compilamos la aplicación y generamos el JAR
+RUN mvn clean package
+
+
+# Etapa 2: Creación de la imagen final y ligera
+# Usamos una imagen solo con el JRE, que es más pequeña
+FROM eclipse-temurin:24-jre-alpine
+
+# Instalar curl en la imagen final
+RUN apk update && apk add curl
+
+# Creamos un usuario y grupo no privilegiados por seguridad
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Establecemos el directorio de trabajo
+WORKDIR /app
+
+# Copiamos el JAR generado desde la etapa de compilación
+# El pom.xml define <finalName>eterea.import-service</finalName>
+COPY --from=build /app/target/eterea.import-service.jar ./eterea.import-service.jar
+
+# Cambiamos al usuario no privilegiado
+USER appuser
+
+# Comando para ejecutar la aplicación
+ENTRYPOINT ["java", "-jar", "eterea.import-service.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-bootstrap</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/eterea/migration/api/rest/client/WordPressApiClient.java
+++ b/src/main/java/eterea/migration/api/rest/client/WordPressApiClient.java
@@ -1,0 +1,110 @@
+package eterea.migration.api.rest.client;
+
+import eterea.migration.api.rest.extern.OrderNoteWeb;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class WordPressApiClient {
+
+   private static final int PER_PAGE = 50; // Maximum value allowed by WordPress API
+   private static final int MAX_PAGES = 100;
+   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+   private static final String ORDER_STATUS_FILTER = "completed,processing,on-hold"; // Comma-separated status values
+
+   private final WebClient webClient;
+   private final String baseUrl;
+   private final String username;
+   private final String password;
+   private final String siteName;
+
+   public WordPressApiClient(String baseUrl, String username, String password, String siteName) {
+      this.baseUrl = baseUrl;
+      this.username = username;
+      this.password = password;
+      this.siteName = siteName;
+      this.webClient = WebClient.builder()
+            .baseUrl(this.baseUrl)
+            .defaultHeaders(headers -> {
+               headers.setBasicAuth(this.username, this.password);
+               headers.setContentType(MediaType.APPLICATION_JSON);
+               headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+            })
+            .build();
+   }
+
+   public List<OrderNoteWeb> fetchOrders(ZonedDateTime dateFrom, ZonedDateTime dateTo) {
+      log.info("[{}] Fetching orders from WordPress API: {} to {}", siteName, dateFrom, dateTo);
+
+      List<OrderNoteWeb> allOrders = new ArrayList<>();
+
+      try {
+         int totalPages = 1;
+         int currentPage = 1;
+
+         while (currentPage <= totalPages && currentPage <= MAX_PAGES) {
+            log.debug("[{}] Fetching page {}/{}", siteName, currentPage, totalPages);
+
+            final int page = currentPage;
+            var responseSpec = webClient.get()
+                  .uri(uriBuilder -> uriBuilder
+                        .queryParam("date_from", dateFrom.format(DATE_FORMATTER))
+                        .queryParam("date_to", dateTo.format(DATE_FORMATTER))
+                        .queryParam("status", ORDER_STATUS_FILTER)
+                        .queryParam("page", page)
+                        .queryParam("per_page", PER_PAGE)
+                        .build())
+                  .retrieve();
+
+            var response = responseSpec
+                  .toEntity(new ParameterizedTypeReference<List<OrderNoteWeb>>() {
+                  })
+                  .block();
+
+            if (response != null && response.getBody() != null) {
+               // Get total pages from header on first request
+               if (currentPage == 1) {
+                  String totalPagesHeader = response.getHeaders().getFirst("x-wp-totalpages");
+                  if (totalPagesHeader != null) {
+                     try {
+                        totalPages = Integer.parseInt(totalPagesHeader);
+                        log.debug("[{}] Total pages available: {}", siteName, totalPages);
+                     } catch (NumberFormatException e) {
+                        log.warn("[{}] Could not parse x-wp-totalpages header: {}", siteName, totalPagesHeader);
+                     }
+                  }
+               }
+
+               for (OrderNoteWeb orderNote : response.getBody()) {
+                  orderNote.setOriginalJson("{\"order_number\": \"" + orderNote.getOrderNumber() + "\"}");
+                  allOrders.add(orderNote);
+               }
+            } else {
+               log.warn("[{}] Empty response received", siteName);
+               break;
+            }
+
+            currentPage++;
+         }
+
+         log.info("[{}] Successfully fetched {} orders", siteName, allOrders.size());
+         return allOrders;
+
+      } catch (WebClientResponseException e) {
+         log.error("[{}] HTTP error ({}): {}", siteName, e.getStatusCode(), e.getMessage());
+         return allOrders;
+      } catch (Exception e) {
+         log.error("[{}] Unexpected error while fetching orders: {}", siteName, e.getMessage(), e);
+         return allOrders;
+      }
+   }
+}

--- a/src/main/java/eterea/migration/api/rest/configuration/EtereaMigrationConfiguration.java
+++ b/src/main/java/eterea/migration/api/rest/configuration/EtereaMigrationConfiguration.java
@@ -20,8 +20,7 @@ public class EtereaMigrationConfiguration {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                );
+                        .anyRequest().permitAll());
         return http.build();
     }
 }

--- a/src/main/java/eterea/migration/api/rest/configuration/WordPressClientConfig.java
+++ b/src/main/java/eterea/migration/api/rest/configuration/WordPressClientConfig.java
@@ -1,0 +1,34 @@
+package eterea.migration.api.rest.configuration;
+
+import eterea.migration.api.rest.client.WordPressApiClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Configuration
+public class WordPressClientConfig {
+
+   private final Environment environment;
+
+   public WordPressClientConfig(Environment environment) {
+      this.environment = environment;
+   }
+
+   @Bean(name = "wordPressApiClientSite1")
+   public WordPressApiClient wordPressApiClientSite1() {
+      String baseUrl = environment.getProperty("app.wordpress.site1.base-url");
+      String username = environment.getProperty("app.wordpress.site1.username");
+      String password = environment.getProperty("app.wordpress.site1.password");
+      String siteName = environment.getProperty("app.wordpress.site1.name", "site1");
+      return new WordPressApiClient(baseUrl, username, password, siteName);
+   }
+
+   @Bean(name = "wordPressApiClientSite2")
+   public WordPressApiClient wordPressApiClientSite2() {
+      String baseUrl = environment.getProperty("app.wordpress.site2.base-url");
+      String username = environment.getProperty("app.wordpress.site2.username");
+      String password = environment.getProperty("app.wordpress.site2.password");
+      String siteName = environment.getProperty("app.wordpress.site2.name", "site2");
+      return new WordPressApiClient(baseUrl, username, password, siteName);
+   }
+}

--- a/src/main/java/eterea/migration/api/rest/controller/facade/WordPressController.java
+++ b/src/main/java/eterea/migration/api/rest/controller/facade/WordPressController.java
@@ -2,29 +2,61 @@ package eterea.migration.api.rest.controller.facade;
 
 import eterea.migration.api.rest.extern.OrderNoteWeb;
 import eterea.migration.api.rest.service.facade.OrderNoteWebService;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/wordpress")
 public class WordPressController {
 
-    private final OrderNoteWebService service;
+   private final OrderNoteWebService service;
 
-    public WordPressController(OrderNoteWebService service) {
-        this.service = service;
-    }
+   public WordPressController(OrderNoteWebService service) {
+      this.service = service;
+   }
 
-    @GetMapping("/capture")
-    @Scheduled(cron = "0 0 * * * *")
-    public ResponseEntity<List<OrderNoteWeb>> capture() {
-        return new ResponseEntity<>(service.capture(), HttpStatus.OK);
-    }
+   @GetMapping("/capture")
+   @Scheduled(cron = "0 0 * * * *")
+   public ResponseEntity<List<OrderNoteWeb>> capture() {
+      return new ResponseEntity<>(service.capture(), HttpStatus.OK);
+   }
+
+   @GetMapping("/capture/from-apis")
+   public ResponseEntity<List<OrderNoteWeb>> captureFromApis(
+         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime from,
+         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime to) {
+
+      ZoneId utcMinus3 = ZoneId.of("America/Argentina/Buenos_Aires");
+      ZonedDateTime fromDateTime = (from != null)
+            ? from
+            : ZonedDateTime.now(utcMinus3).toLocalDate().atStartOfDay(utcMinus3);
+      ZonedDateTime toDateTime = (to != null)
+            ? to
+            : ZonedDateTime.now(utcMinus3).toLocalDate().atTime(23, 59, 59).atZone(utcMinus3);
+
+      return new ResponseEntity<>(service.captureFromApi(fromDateTime, toDateTime), HttpStatus.OK);
+   }
+
+   @GetMapping("/capture/from-apis/last-twelve-hours")
+   @Scheduled(cron = "0 */10 * * * *")
+   public ResponseEntity<List<OrderNoteWeb>> captureFromApisLastTwelveHours() {
+
+      ZoneId utcMinus3 = ZoneId.of("America/Argentina/Buenos_Aires");
+      ZonedDateTime toDateTime = ZonedDateTime.now(utcMinus3);
+      ZonedDateTime fromDateTime = toDateTime.minusHours(12);
+
+      return new ResponseEntity<>(service.captureFromApi(fromDateTime, toDateTime), HttpStatus.OK);
+   }
 
 }

--- a/src/main/java/eterea/migration/api/rest/service/PaymentService.java
+++ b/src/main/java/eterea/migration/api/rest/service/PaymentService.java
@@ -3,17 +3,16 @@ package eterea.migration.api.rest.service;
 import eterea.migration.api.rest.model.Payment;
 import eterea.migration.api.rest.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
 
-    private final PaymentRepository repository;
+   private final PaymentRepository repository;
 
-    public Payment save(Payment payment) {
-        return repository.save(payment);
-    }
+   public Payment save(Payment payment) {
+      return repository.save(payment);
+   }
 
 }

--- a/src/main/java/eterea/migration/api/rest/service/facade/OrderNoteWebService.java
+++ b/src/main/java/eterea/migration/api/rest/service/facade/OrderNoteWebService.java
@@ -3,13 +3,15 @@ package eterea.migration.api.rest.service.facade;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eterea.migration.api.rest.client.WordPressApiClient;
 import eterea.migration.api.rest.exception.ProductException;
 import eterea.migration.api.rest.extern.*;
 import eterea.migration.api.rest.model.*;
 import eterea.migration.api.rest.service.*;
 import eterea.migration.api.rest.service.internal.FileService;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
@@ -17,6 +19,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -24,258 +27,582 @@ import java.util.List;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class OrderNoteWebService {
 
-    private final FileService fileService;
-    private final OrderNoteService orderNoteService;
-    private final ProductService productService;
-    private final PaymentService paymentService;
-    private final InformacionPagadorService informacionPagadorService;
-    private final ProductTransactionService productTransactionService;
+   private final FileService fileService;
+   private final OrderNoteService orderNoteService;
+   private final ProductService productService;
+   private final PaymentService paymentService;
+   private final InformacionPagadorService informacionPagadorService;
+   private final ProductTransactionService productTransactionService;
+   private final WordPressApiClient wordPressApiClientSite1;
+   private final WordPressApiClient wordPressApiClientSite2;
 
-    public List<OrderNoteWeb> capture() {
-        log.info("Capturing orders...");
-        ObjectMapper objectMapper = new ObjectMapper();
-        File file = new File(fileService.getFile());
-        List<OrderNoteWeb> orderNotes = null;
-        try {
-            JsonNode jsonArray = objectMapper.readTree(file);
-            orderNotes = new ArrayList<>();
-            for (JsonNode node : jsonArray) {
-                OrderNoteWeb orderNote = objectMapper.treeToValue(node, OrderNoteWeb.class);
-                orderNote.setOriginalJson(node.toString());
-                orderNotes.add(orderNote);
+   public OrderNoteWebService(
+         FileService fileService,
+         OrderNoteService orderNoteService,
+         ProductService productService,
+         PaymentService paymentService,
+         InformacionPagadorService informacionPagadorService,
+         ProductTransactionService productTransactionService,
+         @Qualifier("wordPressApiClientSite1") WordPressApiClient wordPressApiClientSite1,
+         @Qualifier("wordPressApiClientSite2") WordPressApiClient wordPressApiClientSite2) {
+      this.fileService = fileService;
+      this.orderNoteService = orderNoteService;
+      this.productService = productService;
+      this.paymentService = paymentService;
+      this.informacionPagadorService = informacionPagadorService;
+      this.productTransactionService = productTransactionService;
+      this.wordPressApiClientSite1 = wordPressApiClientSite1;
+      this.wordPressApiClientSite2 = wordPressApiClientSite2;
+   }
+
+   public List<OrderNoteWeb> capture() {
+      log.info("Capturing orders...");
+      ObjectMapper objectMapper = new ObjectMapper();
+      File file = new File(fileService.getFile());
+      List<OrderNoteWeb> orderNotes = null;
+      try {
+         JsonNode jsonArray = objectMapper.readTree(file);
+         orderNotes = new ArrayList<>();
+         for (JsonNode node : jsonArray) {
+            OrderNoteWeb orderNote = objectMapper.treeToValue(node, OrderNoteWeb.class);
+            orderNote.setOriginalJson(node.toString());
+            orderNotes.add(orderNote);
+         }
+
+         for (OrderNoteWeb orderNote : orderNotes) {
+            int inicioPago = orderNote.getOrderNotes().lastIndexOf("PlusPago");
+            int finPago = orderNote.getOrderNotes().indexOf("Una nueva reserva");
+            String plusPagoString = "";
+            if (inicioPago > -1 && finPago > -1) {
+               plusPagoString = orderNote.getOrderNotes().substring(inicioPago + 8, finPago - 1);
+               PaymentWeb payment = objectMapper.readValue(plusPagoString, PaymentWeb.class);
+               orderNote.setPayment(payment);
+            }
+         }
+      } catch (JsonProcessingException e) {
+         log.debug("JsonProcessingException - {}", e.getMessage());
+      } catch (IOException e) {
+         log.debug("IOException - {}", e.getMessage());
+      }
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+      DateTimeFormatter formatterLocal = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
+      assert orderNotes != null;
+      for (OrderNoteWeb orderNoteWeb : orderNotes) {
+         log.info("orderNoteWeb={}", orderNoteWeb);
+         try {
+            OffsetDateTime orderDate = null;
+            if (!orderNoteWeb.getOrderDate().isEmpty()) {
+               orderDate = LocalDateTime.parse(orderNoteWeb.getOrderDate(), formatter).atOffset(ZoneOffset.UTC);
+            }
+            OffsetDateTime paidDate = null;
+            if (!orderNoteWeb.getPaidDate().isEmpty()) {
+               paidDate = LocalDateTime.parse(orderNoteWeb.getPaidDate(), formatter).atOffset(ZoneOffset.UTC);
+            }
+            OffsetDateTime completedDate = null;
+            if (!orderNoteWeb.getCompletedDate().isEmpty()) {
+               completedDate = LocalDateTime.parse(orderNoteWeb.getCompletedDate(), formatter)
+                     .atOffset(ZoneOffset.UTC);
+            }
+            OffsetDateTime modifiedDate = null;
+            if (!orderNoteWeb.getModifiedDate().isEmpty()) {
+               modifiedDate = LocalDateTime.parse(orderNoteWeb.getModifiedDate(), formatter)
+                     .atOffset(ZoneOffset.UTC);
             }
 
-            for (OrderNoteWeb orderNote : orderNotes) {
-                int inicioPago = orderNote.getOrderNotes().lastIndexOf("PlusPago");
-                int finPago = orderNote.getOrderNotes().indexOf("Una nueva reserva");
-                String plusPagoString = "";
-                if (inicioPago > -1 && finPago > -1) {
-                    plusPagoString = orderNote.getOrderNotes().substring(inicioPago + 8, finPago - 1);
-                    PaymentWeb payment = objectMapper.readValue(plusPagoString, PaymentWeb.class);
-                    orderNote.setPayment(payment);
-                }
-            }
-        } catch (JsonProcessingException e) {
-            log.debug("JsonProcessingException - {}", e.getMessage());
-        } catch (IOException e) {
-            log.debug("IOException - {}", e.getMessage());
-        }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        DateTimeFormatter formatterLocal = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
-        assert orderNotes != null;
-        for (OrderNoteWeb orderNoteWeb : orderNotes) {
-            log.info("orderNoteWeb={}", orderNoteWeb);
-            try {
-                OffsetDateTime orderDate = null;
-                if (!orderNoteWeb.getOrderDate().isEmpty()) {
-                    orderDate = LocalDateTime.parse(orderNoteWeb.getOrderDate(), formatter).atOffset(ZoneOffset.UTC);
-                }
-                OffsetDateTime paidDate = null;
-                if (!orderNoteWeb.getPaidDate().isEmpty()) {
-                    paidDate = LocalDateTime.parse(orderNoteWeb.getPaidDate(), formatter).atOffset(ZoneOffset.UTC);
-                }
-                OffsetDateTime completedDate = null;
-                if (!orderNoteWeb.getCompletedDate().isEmpty()) {
-                    completedDate = LocalDateTime.parse(orderNoteWeb.getCompletedDate(), formatter).atOffset(ZoneOffset.UTC);
-                }
-                OffsetDateTime modifiedDate = null;
-                if (!orderNoteWeb.getModifiedDate().isEmpty()) {
-                    modifiedDate = LocalDateTime.parse(orderNoteWeb.getModifiedDate(), formatter).atOffset(ZoneOffset.UTC);
-                }
+            OrderNote orderNote = new OrderNote(
+                  Long.valueOf(orderNoteWeb.getOrderNumber()),
+                  orderNoteWeb.getOrderStatus(),
+                  orderDate,
+                  paidDate,
+                  completedDate,
+                  modifiedDate,
+                  orderNoteWeb.getOrderCurrency(),
+                  orderNoteWeb.getCustomerNote(),
+                  orderNoteWeb.getBillingFirstName(),
+                  orderNoteWeb.getBillingLastName(),
+                  orderNoteWeb.getBillingFullName(),
+                  orderNoteWeb.getBillingDniPasaporte() != null
+                        ? orderNoteWeb.getBillingDniPasaporte().replace(".", "")
+                        : null,
+                  orderNoteWeb.getBillingAddress(),
+                  orderNoteWeb.getBillingCity(),
+                  orderNoteWeb.getBillingState(),
+                  orderNoteWeb.getBillingPostCode(),
+                  orderNoteWeb.getBillingCountry(),
+                  orderNoteWeb.getBillingEmail(),
+                  orderNoteWeb.getBillingPhone(),
+                  orderNoteWeb.getShippingFirstName(),
+                  orderNoteWeb.getShippingLastName(),
+                  orderNoteWeb.getShippingFullName(),
+                  orderNoteWeb.getShippingAddress(),
+                  orderNoteWeb.getShippingCity(),
+                  orderNoteWeb.getShippingState(),
+                  orderNoteWeb.getShippingPostCode(),
+                  orderNoteWeb.getShippingCountryFull(),
+                  orderNoteWeb.getPaymentMethodTitle(),
+                  orderNoteWeb.getCartDiscount(),
+                  orderNoteWeb.getOrderSubtotal(),
+                  orderNoteWeb.getOrderSubtotalRefunded(),
+                  orderNoteWeb.getShippingMethodTitle(),
+                  orderNoteWeb.getOrderShipping(),
+                  orderNoteWeb.getOrderShippingRefunded(),
+                  orderNoteWeb.getOrderTotal(),
+                  orderNoteWeb.getOrderTotalTax(),
+                  orderNoteWeb.getOrderNotes(),
+                  orderNoteWeb.getOriginalJson(),
+                  null,
+                  null);
+            orderNote = orderNoteService.add(orderNote);
+            for (ProductWeb productWeb : orderNoteWeb.getProducts()) {
+               OffsetDateTime bookingStart = null;
+               if (!productWeb.getBookingStart().isEmpty()) {
+                  bookingStart = LocalDateTime.parse(productWeb.getBookingStart() + " 00:00:00", formatter)
+                        .atOffset(ZoneOffset.UTC);
+               }
+               OffsetDateTime bookingEnd = null;
+               if (!productWeb.getBookingEnd().isEmpty()) {
+                  bookingEnd = LocalDateTime.parse(productWeb.getBookingEnd() + " 00:00:00", formatter)
+                        .atOffset(ZoneOffset.UTC);
+               }
 
-                OrderNote orderNote = new OrderNote(
-                        Long.valueOf(orderNoteWeb.getOrderNumber()),
-                        orderNoteWeb.getOrderStatus(),
-                        orderDate,
-                        paidDate,
-                        completedDate,
-                        modifiedDate,
-                        orderNoteWeb.getOrderCurrency(),
-                        orderNoteWeb.getCustomerNote(),
-                        orderNoteWeb.getBillingFirstName(),
-                        orderNoteWeb.getBillingLastName(),
-                        orderNoteWeb.getBillingFullName(),
-                        orderNoteWeb.getBillingDniPasaporte() != null ? orderNoteWeb.getBillingDniPasaporte().replace(".", "") : null,
-                        orderNoteWeb.getBillingAddress(),
-                        orderNoteWeb.getBillingCity(),
-                        orderNoteWeb.getBillingState(),
-                        orderNoteWeb.getBillingPostCode(),
-                        orderNoteWeb.getBillingCountry(),
-                        orderNoteWeb.getBillingEmail(),
-                        orderNoteWeb.getBillingPhone(),
-                        orderNoteWeb.getShippingFirstName(),
-                        orderNoteWeb.getShippingLastName(),
-                        orderNoteWeb.getShippingFullName(),
-                        orderNoteWeb.getShippingAddress(),
-                        orderNoteWeb.getShippingCity(),
-                        orderNoteWeb.getShippingState(),
-                        orderNoteWeb.getShippingPostCode(),
-                        orderNoteWeb.getShippingCountryFull(),
-                        orderNoteWeb.getPaymentMethodTitle(),
-                        orderNoteWeb.getCartDiscount(),
-                        orderNoteWeb.getOrderSubtotal(),
-                        orderNoteWeb.getOrderSubtotalRefunded(),
-                        orderNoteWeb.getShippingMethodTitle(),
-                        orderNoteWeb.getOrderShipping(),
-                        orderNoteWeb.getOrderShippingRefunded(),
-                        orderNoteWeb.getOrderTotal(),
-                        orderNoteWeb.getOrderTotalTax(),
-                        orderNoteWeb.getOrderNotes(),
-                        orderNoteWeb.getOriginalJson(),
+               Long productId = null;
+               try {
+                  productId = productService.findByUnique(orderNote.getOrderNumberId(), productWeb.getLineId())
+                        .getProductId();
+               } catch (ProductException e) {
+                  productId = null;
+               }
+
+               Integer bookingDuration = productWeb.getBookingDuration();
+               if (bookingDuration == null) {
+                  bookingDuration = 0;
+               }
+
+               Integer bookingPersons = productWeb.getBookingPersons();
+               if (bookingPersons == null) {
+                  bookingPersons = 0;
+               }
+
+               Product product = new Product(
+                     productId,
+                     orderNote.getOrderNumberId(),
+                     productWeb.getSku(),
+                     productWeb.getLineId(),
+                     productWeb.getName(),
+                     Integer.parseInt(productWeb.getQty()),
+                     productWeb.getItemPrice(),
+                     bookingStart,
+                     bookingEnd,
+                     bookingDuration,
+                     bookingPersons,
+                     productWeb.getPersonTypes(),
+                     productWeb.getServiciosAdicionales(),
+                     productWeb.getPuntoDeEncuentro(),
+                     productWeb.getEncuentroHotel());
+               product = productService.save(product);
+            }
+            PaymentWeb paymentWeb = orderNoteWeb.getPayment();
+            if (paymentWeb != null) {
+               OffsetDateTime fechaTransaccion = null;
+               if (paymentWeb.getFechaTransaccion() != null) {
+                  fechaTransaccion = LocalDateTime.parse(paymentWeb.getFechaTransaccion(), formatterLocal)
+                        .atOffset(ZoneOffset.UTC);
+               }
+               OffsetDateTime fechaPago = null;
+               if (paymentWeb.getFechaPago() != null) {
+                  fechaPago = LocalDateTime.parse(paymentWeb.getFechaPago(), formatterLocal)
+                        .atOffset(ZoneOffset.UTC);
+               }
+               Integer cuotas = null;
+               if (paymentWeb.getCuotas() != null) {
+                  cuotas = Integer.parseInt(paymentWeb.getCuotas());
+               }
+               Payment payment = new Payment(
+                     orderNote.getOrderNumberId(),
+                     paymentWeb.getTransaccionComercioId(),
+                     paymentWeb.getTransaccionPlataformaId(),
+                     paymentWeb.getTipo(),
+                     new BigDecimal(paymentWeb.getMonto().replace(",", ".")),
+                     paymentWeb.getEstado(),
+                     paymentWeb.getDetalle(),
+                     paymentWeb.getMetodoPago(),
+                     paymentWeb.getMedioPago(),
+                     Integer.valueOf(paymentWeb.getEstadoId()),
+                     cuotas,
+                     paymentWeb.getInformacionAdicional(),
+                     paymentWeb.getMarcaTarjeta(),
+                     paymentWeb.getInformacionAdicionalLink(),
+                     fechaTransaccion,
+                     fechaPago,
+                     null,
+                     null);
+               payment = paymentService.save(payment);
+
+               // Agregado para compensar la falta de date_completed y date_paid en order_note
+               if (orderNote.getCompletedDate() == null) {
+                  orderNote.setCompletedDate(payment.getFechaPago());
+                  if (orderNote.getPaidDate() == null) {
+                     orderNote.setPaidDate(payment.getFechaPago());
+                  }
+                  orderNote = orderNoteService.update(orderNote, orderNote.getOrderNumberId());
+               }
+
+               InformacionPagadorWeb informacionPagadorWeb = paymentWeb.getInformacionPagador();
+               if (informacionPagadorWeb != null) {
+                  if ("0".equals(paymentWeb.getMedioPago())) {
+                     String email = (informacionPagadorWeb.getEMail() == null) ? ""
+                           : informacionPagadorWeb.getEMail();
+                     String nombre = (informacionPagadorWeb.getNombre() == null) ? ""
+                           : informacionPagadorWeb.getNombre();
+                     String numeroDocumento = (informacionPagadorWeb.getNumeroDocumento() == null) ? ""
+                           : informacionPagadorWeb.getNumeroDocumento();
+                     String telefono = (informacionPagadorWeb.getTelefono() == null) ? ""
+                           : informacionPagadorWeb.getTelefono();
+                     String tipoDocumento = (informacionPagadorWeb.getTipoDocumento() == null) ? ""
+                           : informacionPagadorWeb.getTipoDocumento();
+                     InformacionPagador informacionPagador = new InformacionPagador(
+                           payment.getOrderNumberId(),
+                           email,
+                           nombre,
+                           numeroDocumento,
+                           telefono,
+                           tipoDocumento);
+                     log.info("informacionPagador={}", informacionPagador);
+                     informacionPagadorService.save(informacionPagador);
+                  } else {
+                     if (informacionPagadorWeb.getNombre() == null
+                           || informacionPagadorWeb.getNumeroDocumento() == null
+                           || informacionPagadorWeb.getTipoDocumento() == null) {
+                        log.error(
+                              "InformacionPagador data is incomplete for orderNumberId={} and MedioPago is not 0. Skipping save.",
+                              payment.getOrderNumberId());
+                     } else {
+                        InformacionPagador informacionPagador = new InformacionPagador(
+                              payment.getOrderNumberId(),
+                              informacionPagadorWeb.getEMail(),
+                              informacionPagadorWeb.getNombre(),
+                              informacionPagadorWeb.getNumeroDocumento(),
+                              informacionPagadorWeb.getTelefono(),
+                              informacionPagadorWeb.getTipoDocumento());
+                        log.info("informacionPagador={}", informacionPagador);
+                        informacionPagadorService.save(informacionPagador);
+                     }
+                  }
+               }
+
+               productTransactionService.deleteAllByOrderNumberId(orderNote.getOrderNumberId());
+
+               for (ProductTransactionWeb productTransactionWeb : paymentWeb.getProductoTransactions()) {
+                  ProductTransaction productTransaction = new ProductTransaction(
                         null,
-                        null
-                );
-                orderNote = orderNoteService.add(orderNote);
-                for (ProductWeb productWeb : orderNoteWeb.getProducts()) {
-                    OffsetDateTime bookingStart = null;
-                    if (!productWeb.getBookingStart().isEmpty()) {
-                        bookingStart = LocalDateTime.parse(productWeb.getBookingStart() + " 00:00:00", formatter).atOffset(ZoneOffset.UTC);
-                    }
-                    OffsetDateTime bookingEnd = null;
-                    if (!productWeb.getBookingEnd().isEmpty()) {
-                        bookingEnd = LocalDateTime.parse(productWeb.getBookingEnd() + " 00:00:00", formatter).atOffset(ZoneOffset.UTC);
-                    }
+                        orderNote.getOrderNumberId(),
+                        productTransactionWeb.getNombreProducto(),
+                        productTransactionWeb.getMontoProducto());
+                  productTransaction = productTransactionService.save(productTransaction);
+               }
+            }
+         } catch (NumberFormatException e) {
+            log.info("Error importing -> {}", e.getMessage());
+         }
 
-                    Long productId = null;
-                    try {
-                        productId = productService.findByUnique(orderNote.getOrderNumberId(), productWeb.getLineId()).getProductId();
-                    } catch (ProductException e) {
-                        productId = null;
-                    }
+      }
 
-                    Integer bookingDuration = productWeb.getBookingDuration();
-                    if (bookingDuration == null) {
-                        bookingDuration = 0;
-                    }
+      return orderNotes;
 
-                    Integer bookingPersons = productWeb.getBookingPersons();
-                    if (bookingPersons == null) {
-                        bookingPersons = 0;
-                    }
+   }
 
-                    Product product = new Product(
-                            productId,
-                            orderNote.getOrderNumberId(),
-                            productWeb.getSku(),
-                            productWeb.getLineId(),
-                            productWeb.getName(),
-                            Integer.parseInt(productWeb.getQty()),
-                            productWeb.getItemPrice(),
-                            bookingStart,
-                            bookingEnd,
-                            bookingDuration,
-                            bookingPersons,
-                            productWeb.getPersonTypes(),
-                            productWeb.getServiciosAdicionales(),
-                            productWeb.getPuntoDeEncuentro(),
-                            productWeb.getEncuentroHotel()
-                    );
-                    product = productService.save(product);
-                }
-                PaymentWeb paymentWeb = orderNoteWeb.getPayment();
-                if (paymentWeb != null) {
-                    OffsetDateTime fechaTransaccion = null;
-                    if (paymentWeb.getFechaTransaccion() != null) {
-                        fechaTransaccion = LocalDateTime.parse(paymentWeb.getFechaTransaccion(), formatterLocal).atOffset(ZoneOffset.UTC);
-                    }
-                    OffsetDateTime fechaPago = null;
-                    if (paymentWeb.getFechaPago() != null) {
-                        fechaPago = LocalDateTime.parse(paymentWeb.getFechaPago(), formatterLocal).atOffset(ZoneOffset.UTC);
-                    }
-                    Integer cuotas = null;
-                    if (paymentWeb.getCuotas() != null) {
-                        cuotas = Integer.parseInt(paymentWeb.getCuotas());
-                    }
-                    Payment payment = new Payment(
-                            orderNote.getOrderNumberId(),
-                            paymentWeb.getTransaccionComercioId(),
-                            paymentWeb.getTransaccionPlataformaId(),
-                            paymentWeb.getTipo(),
-                            new BigDecimal(paymentWeb.getMonto().replace(",", ".")),
-                            paymentWeb.getEstado(),
-                            paymentWeb.getDetalle(),
-                            paymentWeb.getMetodoPago(),
-                            paymentWeb.getMedioPago(),
-                            Integer.valueOf(paymentWeb.getEstadoId()),
-                            cuotas,
-                            paymentWeb.getInformacionAdicional(),
-                            paymentWeb.getMarcaTarjeta(),
-                            paymentWeb.getInformacionAdicionalLink(),
-                            fechaTransaccion,
-                            fechaPago,
-                            null,
-                            null
-                    );
-                    payment = paymentService.save(payment);
+   public List<OrderNoteWeb> captureFromApi(ZonedDateTime from, ZonedDateTime to) {
+      log.info("Capturing orders from Wordpress APIs: {} to {}", from, to);
 
-                    // Agregado para compensar la falta de date_completed y date_paid en order_note
-                    if (orderNote.getCompletedDate() == null) {
-                        orderNote.setCompletedDate(payment.getFechaPago());
-                        if (orderNote.getPaidDate() == null) {
-                            orderNote.setPaidDate(payment.getFechaPago());
-                        }
-                        orderNote = orderNoteService.update(orderNote, orderNote.getOrderNumberId());
-                    }
+      List<OrderNoteWeb> orderNotesSite1 = wordPressApiClientSite1.fetchOrders(from, to);
+      List<OrderNoteWeb> orderNotesSite2 = wordPressApiClientSite2.fetchOrders(from, to);
 
-                    InformacionPagadorWeb informacionPagadorWeb = paymentWeb.getInformacionPagador();
-                    if (informacionPagadorWeb != null) {
-                        if ("0".equals(paymentWeb.getMedioPago())) {
-                            String email = (informacionPagadorWeb.getEMail() == null) ? "" : informacionPagadorWeb.getEMail();
-                            String nombre = (informacionPagadorWeb.getNombre() == null) ? "" : informacionPagadorWeb.getNombre();
-                            String numeroDocumento = (informacionPagadorWeb.getNumeroDocumento() == null) ? "" : informacionPagadorWeb.getNumeroDocumento();
-                            String telefono = (informacionPagadorWeb.getTelefono() == null) ? "" : informacionPagadorWeb.getTelefono();
-                            String tipoDocumento = (informacionPagadorWeb.getTipoDocumento() == null) ? "" : informacionPagadorWeb.getTipoDocumento();
-                            InformacionPagador informacionPagador = new InformacionPagador(
-                                    payment.getOrderNumberId(),
-                                    email,
-                                    nombre,
-                                    numeroDocumento,
-                                    telefono,
-                                    tipoDocumento
-                            );
-                            log.info("informacionPagador={}", informacionPagador);
-                            informacionPagadorService.save(informacionPagador);
-                        } else {
-                            if (informacionPagadorWeb.getNombre() == null || informacionPagadorWeb.getNumeroDocumento() == null || informacionPagadorWeb.getTipoDocumento() == null) {
-                                log.error("InformacionPagador data is incomplete for orderNumberId={} and MedioPago is not 0. Skipping save.", payment.getOrderNumberId());
-                            } else {
-                                InformacionPagador informacionPagador = new InformacionPagador(
-                                        payment.getOrderNumberId(),
-                                        informacionPagadorWeb.getEMail(),
-                                        informacionPagadorWeb.getNombre(),
-                                        informacionPagadorWeb.getNumeroDocumento(),
-                                        informacionPagadorWeb.getTelefono(),
-                                        informacionPagadorWeb.getTipoDocumento()
-                                );
-                                log.info("informacionPagador={}", informacionPagador);
-                                informacionPagadorService.save(informacionPagador);
-                            }
-                        }
-                    }
+      if (orderNotesSite1 == null) {
+         orderNotesSite1 = new ArrayList<>();
+      }
+      if (orderNotesSite2 == null) {
+         orderNotesSite2 = new ArrayList<>();
+      }
 
-                    productTransactionService.deleteAllByOrderNumberId(orderNote.getOrderNumberId());
+      List<OrderNoteWeb> allOrderNotes = new ArrayList<>();
+      allOrderNotes.addAll(orderNotesSite1);
+      allOrderNotes.addAll(orderNotesSite2);
 
-                    for (ProductTransactionWeb productTransactionWeb : paymentWeb.getProductoTransactions()) {
-                        ProductTransaction productTransaction = new ProductTransaction(
-                                null,
-                                orderNote.getOrderNumberId(),
-                                productTransactionWeb.getNombreProducto(),
-                                productTransactionWeb.getMontoProducto()
-                        );
-                        productTransaction = productTransactionService.save(productTransaction);
-                    }
-                }
-            } catch (NumberFormatException e) {
-                log.info("Error importing -> {}", e.getMessage());
+      log.info("Total orders fetched: {} (Site1: {}, Site2: {})",
+            allOrderNotes.size(), orderNotesSite1.size(), orderNotesSite2.size());
+
+      if (allOrderNotes.isEmpty()) {
+         log.warn("No orders fetched from any API");
+         return allOrderNotes;
+      }
+
+      processOrderNotes(allOrderNotes);
+
+      return allOrderNotes;
+   }
+
+   private void extractPaymentFromOrderNotes(OrderNoteWeb orderNote) {
+      if (orderNote.getOrderNotes() == null || orderNote.getOrderNotes().isEmpty()) {
+         return;
+      }
+
+      try {
+         int inicioPago = orderNote.getOrderNotes().lastIndexOf("PlusPago");
+         String paymentType = "PlusPago";
+         int paymentTypeLength = 8; // "PlusPago" word length
+
+         // If PlusPago not found, try MacroClick
+         if (inicioPago == -1) {
+            inicioPago = orderNote.getOrderNotes().lastIndexOf("MacroClick");
+            paymentType = "MacroClick";
+            paymentTypeLength = 10; // "MacroClick" word length
+         }
+
+         int finPago = orderNote.getOrderNotes().indexOf("Una nueva reserva");
+
+         if (inicioPago > -1 && finPago > -1) {
+            String paymentString = orderNote.getOrderNotes().substring(inicioPago + paymentTypeLength, finPago - 1);
+            PaymentWeb payment = new ObjectMapper().readValue(paymentString, PaymentWeb.class);
+            orderNote.setPayment(payment);
+            log.debug("Extracted {} payment data for order {}", paymentType, orderNote.getOrderNumber());
+         }
+      } catch (JsonProcessingException e) {
+         log.warn("Could not parse PaymentWeb from order_notes for order {}: {}",
+               orderNote.getOrderNumber(), e.getMessage());
+      }
+   }
+
+   private void processOrderNotes(List<OrderNoteWeb> orderNotes) {
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+      DateTimeFormatter formatterLocal = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
+
+      for (OrderNoteWeb orderNoteWeb : orderNotes) {
+         log.info("Processing orderNoteWeb={}", orderNoteWeb);
+         try {
+            extractPaymentFromOrderNotes(orderNoteWeb);
+            OffsetDateTime orderDate = null;
+            if (orderNoteWeb.getOrderDate() != null && !orderNoteWeb.getOrderDate().isEmpty()) {
+               orderDate = LocalDateTime.parse(orderNoteWeb.getOrderDate(), formatter).atOffset(ZoneOffset.UTC);
+            }
+            OffsetDateTime paidDate = null;
+            if (orderNoteWeb.getPaidDate() != null && !orderNoteWeb.getPaidDate().isEmpty()) {
+               paidDate = LocalDateTime.parse(orderNoteWeb.getPaidDate(), formatter).atOffset(ZoneOffset.UTC);
+            }
+            OffsetDateTime completedDate = null;
+            if (orderNoteWeb.getCompletedDate() != null && !orderNoteWeb.getCompletedDate().isEmpty()) {
+               completedDate = LocalDateTime.parse(orderNoteWeb.getCompletedDate(), formatter)
+                     .atOffset(ZoneOffset.UTC);
+            }
+            OffsetDateTime modifiedDate = null;
+            if (orderNoteWeb.getModifiedDate() != null && !orderNoteWeb.getModifiedDate().isEmpty()) {
+               modifiedDate = LocalDateTime.parse(orderNoteWeb.getModifiedDate(), formatter)
+                     .atOffset(ZoneOffset.UTC);
             }
 
-        }
+            OrderNote orderNote = new OrderNote(
+                  Long.valueOf(orderNoteWeb.getOrderNumber()),
+                  orderNoteWeb.getOrderStatus(),
+                  orderDate,
+                  paidDate,
+                  completedDate,
+                  modifiedDate,
+                  orderNoteWeb.getOrderCurrency(),
+                  orderNoteWeb.getCustomerNote(),
+                  orderNoteWeb.getBillingFirstName(),
+                  orderNoteWeb.getBillingLastName(),
+                  orderNoteWeb.getBillingFullName(),
+                  orderNoteWeb.getBillingDniPasaporte() != null
+                        ? orderNoteWeb.getBillingDniPasaporte().replace(".", "")
+                        : null,
+                  orderNoteWeb.getBillingAddress(),
+                  orderNoteWeb.getBillingCity(),
+                  orderNoteWeb.getBillingState(),
+                  orderNoteWeb.getBillingPostCode(),
+                  orderNoteWeb.getBillingCountry(),
+                  orderNoteWeb.getBillingEmail(),
+                  orderNoteWeb.getBillingPhone(),
+                  orderNoteWeb.getShippingFirstName(),
+                  orderNoteWeb.getShippingLastName(),
+                  orderNoteWeb.getShippingFullName(),
+                  orderNoteWeb.getShippingAddress(),
+                  orderNoteWeb.getShippingCity(),
+                  orderNoteWeb.getShippingState(),
+                  orderNoteWeb.getShippingPostCode(),
+                  orderNoteWeb.getShippingCountryFull(),
+                  orderNoteWeb.getPaymentMethodTitle(),
+                  orderNoteWeb.getCartDiscount(),
+                  orderNoteWeb.getOrderSubtotal(),
+                  orderNoteWeb.getOrderSubtotalRefunded(),
+                  orderNoteWeb.getShippingMethodTitle(),
+                  orderNoteWeb.getOrderShipping(),
+                  orderNoteWeb.getOrderShippingRefunded(),
+                  orderNoteWeb.getOrderTotal(),
+                  orderNoteWeb.getOrderTotalTax(),
+                  orderNoteWeb.getOrderNotes(),
+                  orderNoteWeb.getOriginalJson(),
+                  null,
+                  null);
+            orderNote = orderNoteService.add(orderNote);
 
-        return orderNotes;
+            if (orderNoteWeb.getProducts() != null) {
+               for (ProductWeb productWeb : orderNoteWeb.getProducts()) {
+                  OffsetDateTime bookingStart = null;
+                  if (productWeb.getBookingStart() != null && !productWeb.getBookingStart().isEmpty()) {
+                     bookingStart = LocalDateTime.parse(productWeb.getBookingStart() + " 00:00:00", formatter)
+                           .atOffset(ZoneOffset.UTC);
+                  }
+                  OffsetDateTime bookingEnd = null;
+                  if (productWeb.getBookingEnd() != null && !productWeb.getBookingEnd().isEmpty()) {
+                     bookingEnd = LocalDateTime.parse(productWeb.getBookingEnd() + " 00:00:00", formatter)
+                           .atOffset(ZoneOffset.UTC);
+                  }
 
-    }
+                  Long productId = null;
+                  try {
+                     productId = productService
+                           .findByUnique(orderNote.getOrderNumberId(), productWeb.getLineId()).getProductId();
+                  } catch (ProductException e) {
+                     productId = null;
+                  }
+
+                  Integer bookingDuration = productWeb.getBookingDuration();
+                  if (bookingDuration == null) {
+                     bookingDuration = 0;
+                  }
+
+                  Integer bookingPersons = productWeb.getBookingPersons();
+                  if (bookingPersons == null) {
+                     bookingPersons = 0;
+                  }
+
+                  Product product = new Product(
+                        productId,
+                        orderNote.getOrderNumberId(),
+                        productWeb.getSku(),
+                        productWeb.getLineId(),
+                        productWeb.getName(),
+                        Integer.parseInt(productWeb.getQty()),
+                        productWeb.getItemPrice(),
+                        bookingStart,
+                        bookingEnd,
+                        bookingDuration,
+                        bookingPersons,
+                        productWeb.getPersonTypes(),
+                        productWeb.getServiciosAdicionales(),
+                        productWeb.getPuntoDeEncuentro(),
+                        productWeb.getEncuentroHotel());
+                  productService.save(product);
+               }
+            }
+
+            PaymentWeb paymentWeb = orderNoteWeb.getPayment();
+            if (paymentWeb != null) {
+               OffsetDateTime fechaTransaccion = null;
+               if (paymentWeb.getFechaTransaccion() != null) {
+                  fechaTransaccion = LocalDateTime.parse(paymentWeb.getFechaTransaccion(), formatterLocal)
+                        .atOffset(ZoneOffset.UTC);
+               }
+               OffsetDateTime fechaPago = null;
+               if (paymentWeb.getFechaPago() != null) {
+                  fechaPago = LocalDateTime.parse(paymentWeb.getFechaPago(), formatterLocal)
+                        .atOffset(ZoneOffset.UTC);
+               }
+               Integer cuotas = null;
+               if (paymentWeb.getCuotas() != null) {
+                  cuotas = Integer.parseInt(paymentWeb.getCuotas());
+               }
+               Payment payment = new Payment(
+                     orderNote.getOrderNumberId(),
+                     paymentWeb.getTransaccionComercioId(),
+                     paymentWeb.getTransaccionPlataformaId(),
+                     paymentWeb.getTipo(),
+                     new BigDecimal(paymentWeb.getMonto().replace(",", ".")),
+                     paymentWeb.getEstado(),
+                     paymentWeb.getDetalle(),
+                     paymentWeb.getMetodoPago(),
+                     paymentWeb.getMedioPago(),
+                     Integer.valueOf(paymentWeb.getEstadoId()),
+                     cuotas,
+                     paymentWeb.getInformacionAdicional(),
+                     paymentWeb.getMarcaTarjeta(),
+                     paymentWeb.getInformacionAdicionalLink(),
+                     fechaTransaccion,
+                     fechaPago,
+                     null,
+                     null);
+               payment = paymentService.save(payment);
+
+               // Agregado para compensar la falta de date_completed y date_paid en order_note
+               if (orderNote.getCompletedDate() == null) {
+                  orderNote.setCompletedDate(payment.getFechaPago());
+                  if (orderNote.getPaidDate() == null) {
+                     orderNote.setPaidDate(payment.getFechaPago());
+                  }
+                  orderNote = orderNoteService.update(orderNote, orderNote.getOrderNumberId());
+               }
+
+               InformacionPagadorWeb informacionPagadorWeb = paymentWeb.getInformacionPagador();
+               if (informacionPagadorWeb != null) {
+                  if ("0".equals(paymentWeb.getMedioPago())) {
+                     String email = (informacionPagadorWeb.getEMail() == null) ? ""
+                           : informacionPagadorWeb.getEMail();
+                     String nombre = (informacionPagadorWeb.getNombre() == null) ? ""
+                           : informacionPagadorWeb.getNombre();
+                     String numeroDocumento = (informacionPagadorWeb.getNumeroDocumento() == null) ? ""
+                           : informacionPagadorWeb.getNumeroDocumento();
+                     String telefono = (informacionPagadorWeb.getTelefono() == null) ? ""
+                           : informacionPagadorWeb.getTelefono();
+                     String tipoDocumento = (informacionPagadorWeb.getTipoDocumento() == null) ? ""
+                           : informacionPagadorWeb.getTipoDocumento();
+                     InformacionPagador informacionPagador = new InformacionPagador(
+                           payment.getOrderNumberId(),
+                           email,
+                           nombre,
+                           numeroDocumento,
+                           telefono,
+                           tipoDocumento);
+                     log.info("informacionPagador={}", informacionPagador);
+                     informacionPagadorService.save(informacionPagador);
+                  } else {
+                     if (informacionPagadorWeb.getNombre() == null
+                           || informacionPagadorWeb.getNumeroDocumento() == null
+                           || informacionPagadorWeb.getTipoDocumento() == null) {
+                        log.error(
+                              "InformacionPagador data is incomplete for orderNumberId={} and MedioPago is not 0. Skipping save.",
+                              payment.getOrderNumberId());
+                     } else {
+                        InformacionPagador informacionPagador = new InformacionPagador(
+                              payment.getOrderNumberId(),
+                              informacionPagadorWeb.getEMail(),
+                              informacionPagadorWeb.getNombre(),
+                              informacionPagadorWeb.getNumeroDocumento(),
+                              informacionPagadorWeb.getTelefono(),
+                              informacionPagadorWeb.getTipoDocumento());
+                        log.info("informacionPagador={}", informacionPagador);
+                        informacionPagadorService.save(informacionPagador);
+                     }
+                  }
+               }
+
+               productTransactionService.deleteAllByOrderNumberId(orderNote.getOrderNumberId());
+
+               if (paymentWeb.getProductoTransactions() != null) {
+                  for (ProductTransactionWeb productTransactionWeb : paymentWeb.getProductoTransactions()) {
+                     ProductTransaction productTransaction = new ProductTransaction(
+                           null,
+                           orderNote.getOrderNumberId(),
+                           productTransactionWeb.getNombreProducto(),
+                           productTransactionWeb.getMontoProducto());
+                     productTransactionService.save(productTransaction);
+                  }
+               }
+            }
+         } catch (NumberFormatException e) {
+            log.info("Error importing -> {}", e.getMessage());
+         }
+      }
+   }
 
 }

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -13,6 +13,17 @@ app:
   ftp-password: pwd
   hours-offset: 1
   local-path: /tmp/
+  wordpress:
+    site1:
+      name: hoteltermascacheuta
+      base-url: ${WORDPRESS_SITE1_BASE_URL:https://hoteltermascacheuta.com/wp-json/custom-orders/v1/orders}
+      username: ${WORDPRESS_SITE1_USERNAME}
+      password: ${WORDPRESS_SITE1_PASSWORD}
+    site2:
+      name: termascacheuta
+      base-url: ${WORDPRESS_SITE2_BASE_URL:https://termascacheuta.com/wp-json/custom-orders/v1/orders}
+      username: ${WORDPRESS_SITE2_USERNAME}
+      password: ${WORDPRESS_SITE2_PASSWORD}
 
 server:
   port: ${app.port}


### PR DESCRIPTION
## Resumen
  - Nueva integración con API REST de WordPress para dos sitios simultáneamente (hoteltermascacheuta.com y termascacheuta.com)
  - Manejo explícito de timezone UTC-3 (Argentina) con ZonedDateTime para comunicarse con Wordpress REST API
  - Endpoint automático para capturar órdenes de las últimas 12 horas cada 10 minutos

## Cambios principales
  - `WordPressApiClient`: Cliente para comunicación con WordPress REST API
  - `WordPressClientConfig`: Configuración multi-sitio con beans independientes
  - `captureFromApi()`: Captura y combina órdenes de ambos sitios
  - `captureFromApisLastTwelveHours()`: Método que ejecuta cada 10 minutos
  - Soporte para pagos extracción de pagos desde "PlusPago" y "MacroClick"
  - Filtrado por estado de orden (completed, processing, on-hold)