### PR TITLE
feat(ordernote): añade enpoint de estado del servicio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## [Unreleased]
 ### Added
+- Nuevo DTO `ServiceStatusDto` para representar el estado del servicio.
+- Nuevo endpoint `GET /service-status` para obtener el estado del servicio con información de última actualización.
+- Nuevo método `getServiceStatus()` en `OrderNoteService` que calcula estadísticas de la última hora de órdenes.
+- Nuevo método `countByCreatedBetween()` en `OrderNoteRepository` para contar órdenes en un rango de tiempo.
+
+## [2.0.1] - 2025-12-15
+### Added
 - Nueva clase `WordPressApiClient` para comunicarse con REST API de Wordpress.
 - Nueva clase `WordPressClientConfig` para crear dos instancias de `WordPressApiClient` con configuración independiente desde `bootstrap.yml`.
 - Soporte para múltiples sitios WordPress simultáneamente.

--- a/src/main/java/eterea/migration/api/dto/ServiceStatusDto.java
+++ b/src/main/java/eterea/migration/api/dto/ServiceStatusDto.java
@@ -1,0 +1,12 @@
+package eterea.migration.api.dto;
+
+import java.time.LocalDateTime;
+
+public record ServiceStatusDto(
+    LocalDateTime lastUpdate,
+    int lastUpdateCount,
+    long lastOrderNumberId,
+    long minutesSinceLastUpdate
+) {
+   
+}

--- a/src/main/java/eterea/migration/api/rest/controller/OrderNoteController.java
+++ b/src/main/java/eterea/migration/api/rest/controller/OrderNoteController.java
@@ -1,5 +1,6 @@
 package eterea.migration.api.rest.controller;
 
+import eterea.migration.api.dto.ServiceStatusDto;
 import eterea.migration.api.rest.exception.OrderNoteException;
 import eterea.migration.api.rest.model.OrderNote;
 import eterea.migration.api.rest.service.OrderNoteService;
@@ -53,4 +54,13 @@ public class OrderNoteController {
         return new ResponseEntity<>(service.findAllCompletedByLastTwoDays(), HttpStatus.OK);
     }
 
+    @GetMapping("/last")
+    public ResponseEntity<OrderNote> findLast() {
+        return new ResponseEntity<>(service.findLast(), HttpStatus.OK);
+    }
+
+    @GetMapping("/service-status")
+    public ResponseEntity<ServiceStatusDto> getServiceStatus() {
+        return new ResponseEntity<>(service.getServiceStatus(), HttpStatus.OK);
+    }
 }

--- a/src/main/java/eterea/migration/api/rest/exception/OrderNoteException.java
+++ b/src/main/java/eterea/migration/api/rest/exception/OrderNoteException.java
@@ -12,4 +12,8 @@ public class OrderNoteException extends RuntimeException {
         super("Cannot find OrderNote by numeroDocumento " + numeroDocumento + " and importe " + importe);
     }
 
+    public OrderNoteException(String message) {
+        super(message);
+    }
+
 }

--- a/src/main/java/eterea/migration/api/rest/repository/OrderNoteRepository.java
+++ b/src/main/java/eterea/migration/api/rest/repository/OrderNoteRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +23,7 @@ public interface OrderNoteRepository extends JpaRepository<OrderNote, Long> {
 
     List<OrderNote> findAllByOrderStatusInAndCompletedDateGreaterThanEqual(List<String> orderStatus, OffsetDateTime completedDate);
 
+    Optional<OrderNote> findTopByOrderByCreatedDesc();
+
+    int countByCreatedBetween(LocalDateTime start, LocalDateTime end);
 }


### PR DESCRIPTION
## Resumen

  - Nuevo endpoint para monitorear el estado del servicio de importación de órdenes
  - Proporciona información sobre la última actualización, cantidad de órdenes procesadas por hora y tiempo transcurrido desde la última orden

  ## Cambios principales

  - `ServiceStatusDto`: DTO que representa el estado del servicio con información de última actualización, contador de órdenes y tiempo transcurrido
  - `GET /service-status`: Endpoint para obtener el estado actual del servicio
  - `getServiceStatus()`: Método que calcula estadísticas de la última hora de órdenes procesadas
  - `countByCreatedBetween()`: Método de repositorio para contar órdenes en un rango de tiempo específico