### PR TITLE
feat(deps): upgrade to Spring Boot 4.0.1 and JDK 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,10 +22,10 @@ jobs:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 ### Fixed
 - Mejoras menores de robustez y limpieza de código.
 
+## [2.0.0] - 2026-01-06
+### Changed
+- Actualización a Spring Boot 4.0.1, incluyendo cambios en dependencias de test (@WebMvcTest, @MockBean -> @MockitoBean, etc.).
+- Actualización de JDK a 25.
+- Actualización de dependencias: Spring Cloud 2025.1.0, MySQL Connector 9.5.0, SpringDoc OpenAPI 3.0.1, commons-lang3 3.20.0.
+- Refactorización en FileService: agregado timeout para conexiones SFTP, uso de @RequiredArgsConstructor.
+- Cambio en frecuencia de scheduling en WordPressController: de cada hora a cada 30 minutos.
+- Actualizaciones en Dockerfile y CI/CD para JDK 25.
+
+> Fuente: análisis de `git diff HEAD`, `pom.xml`, `Dockerfile`, `.github/workflows/maven.yml`, y cambios en código fuente.
+
 ## [1.0.1] - 2025-09-21
 ### Changed
 - Actualización de dependencias: Spring Boot 3.5.6, springdoc-openapi 2.8.10.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ETEREA.import-service
 
 [![ETEREA.import-service CI](https://github.com/ETEREA-services/ETEREA.import-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.import-service/actions/workflows/maven.yml)
-[![Java](https://img.shields.io/badge/Java-24-blue.svg)](https://www.java.com)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-green.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
-[![MySQL](https://img.shields.io/badge/MySQL-9.3.0-blue.svg)](https://www.mysql.com)
-[![OpenAPI](https://img.shields.io/badge/OpenAPI-2.8.10-green.svg)](https://www.openapis.org)
+[![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.java.com)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.1-green.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
+[![MySQL](https://img.shields.io/badge/MySQL-9.5.0-blue.svg)](https://www.mysql.com)
+[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.1-green.svg)](https://www.openapis.org)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ETEREA-services_ETEREA.import-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ETEREA-services_ETEREA.import-service)
 
@@ -49,7 +49,7 @@ mvn test
 ```
 ## Tecnologías Utilizadas
 
-- **Java 24**: Lenguaje base del proyecto
+- **Java 25**: Lenguaje base del proyecto
 
 El pipeline de CI/CD construye y publica automáticamente una imagen Docker estándar basada en JVM.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,21 +5,21 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>4.0.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>import.eterea</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0</version>
     <name>ETEREA.import-service</name>
     <description>Eterea Migration</description>
     <properties>
-        <java.version>24</java.version>
+        <java.version>25</java.version>
         <sonar.organization>eterea-services</sonar.organization>
         <sonar.projectKey>ETEREA-services_ETEREA.import-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <spring-cloud.version>2025.1.0</spring-cloud.version>
     </properties>
     <dependencies>
         <dependency>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.4.0</version>
+            <version>9.5.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,17 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -116,7 +126,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -140,7 +150,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <executable>true</executable>
                     <mainClass>eterea.migration.api.rest.EtereaMigrationApplication</mainClass>
                 </configuration>
             </plugin>

--- a/src/main/java/eterea/migration/api/rest/controller/facade/WordPressController.java
+++ b/src/main/java/eterea/migration/api/rest/controller/facade/WordPressController.java
@@ -27,7 +27,7 @@ public class WordPressController {
    }
 
    @GetMapping("/capture")
-   @Scheduled(cron = "0 0 * * * *")
+   @Scheduled(cron = "0 0/30 * * * ?")
    public ResponseEntity<List<OrderNoteWeb>> capture() {
       return new ResponseEntity<>(service.capture(), HttpStatus.OK);
    }

--- a/src/main/java/eterea/migration/api/rest/service/internal/FileService.java
+++ b/src/main/java/eterea/migration/api/rest/service/internal/FileService.java
@@ -1,8 +1,8 @@
 package eterea.migration.api.rest.service.internal;
 
 import com.jcraft.jsch.*;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
@@ -11,14 +11,10 @@ import java.util.Objects;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class FileService {
 
     private final Environment environment;
-
-    @Autowired
-    public FileService(Environment environment) {
-        this.environment = environment;
-    }
 
     public String getFile() {
 
@@ -34,6 +30,7 @@ public class FileService {
         int ftpPort = 22;
         String ftpUser = environment.getProperty("app.ftp-user");
         String ftpPassword = environment.getProperty("app.ftp-password");
+        int ftpTimeout = Integer.parseInt(Objects.requireNonNull(environment.getProperty("app.ftp-timeout")));
         String remoteFilePath = "/home/ftp-agencia/" + filename;
         filename = environment.getProperty("app.local-path") + filename;
 
@@ -47,10 +44,10 @@ public class FileService {
             config.put("StrictHostKeyChecking", "no");
             session.setConfig(config);
 
-            session.connect();
+            session.connect(ftpTimeout);
 
             Channel channel = session.openChannel("sftp");
-            channel.connect();
+            channel.connect(ftpTimeout);
 
             ChannelSftp sftpChannel = (ChannelSftp) channel;
             sftpChannel.get(remoteFilePath, filename);

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -11,6 +11,7 @@ app:
   ftp-host: 127.0.0.1
   ftp-user: ftp-uid
   ftp-password: pwd
+  ftp-timeout: 60000
   hours-offset: 1
   local-path: /tmp/
   wordpress:

--- a/src/test/java/eterea/migration/api/rest/controller/OrderNoteControllerTest.java
+++ b/src/test/java/eterea/migration/api/rest/controller/OrderNoteControllerTest.java
@@ -5,8 +5,8 @@ import eterea.migration.api.rest.service.OrderNoteService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,7 +23,7 @@ class OrderNoteControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private OrderNoteService orderNoteService;
 
     private OrderNote orderNote;

--- a/src/test/java/eterea/migration/api/rest/controller/facade/WordPressControllerTest.java
+++ b/src/test/java/eterea/migration/api/rest/controller/facade/WordPressControllerTest.java
@@ -3,8 +3,8 @@ package eterea.migration.api.rest.controller.facade;
 import eterea.migration.api.rest.service.facade.OrderNoteWebService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -21,7 +21,7 @@ class WordPressControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private OrderNoteWebService orderNoteWebService;
 
     @Test

--- a/src/test/java/eterea/migration/api/rest/repository/InformacionPagadorRepositoryTest.java
+++ b/src/test/java/eterea/migration/api/rest/repository/InformacionPagadorRepositoryTest.java
@@ -4,8 +4,8 @@ import eterea.migration.api.rest.configuration.EtereaMigrationConfiguration;
 import eterea.migration.api.rest.model.InformacionPagador;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 import java.util.Optional;

--- a/src/test/java/eterea/migration/api/rest/repository/OrderNoteRepositoryTest.java
+++ b/src/test/java/eterea/migration/api/rest/repository/OrderNoteRepositoryTest.java
@@ -4,8 +4,8 @@ import eterea.migration.api.rest.configuration.EtereaMigrationConfiguration;
 import eterea.migration.api.rest.model.OrderNote;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 import java.math.BigDecimal;

--- a/src/test/java/eterea/migration/api/rest/repository/PaymentRepositoryTest.java
+++ b/src/test/java/eterea/migration/api/rest/repository/PaymentRepositoryTest.java
@@ -4,8 +4,8 @@ import eterea.migration.api.rest.configuration.EtereaMigrationConfiguration;
 import eterea.migration.api.rest.model.Payment;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 import java.math.BigDecimal;

--- a/src/test/java/eterea/migration/api/rest/repository/ProductRepositoryTest.java
+++ b/src/test/java/eterea/migration/api/rest/repository/ProductRepositoryTest.java
@@ -4,8 +4,8 @@ import eterea.migration.api.rest.configuration.EtereaMigrationConfiguration;
 import eterea.migration.api.rest.model.Product;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 import java.util.Optional;

--- a/src/test/java/eterea/migration/api/rest/repository/ProductTransactionRepositoryTest.java
+++ b/src/test/java/eterea/migration/api/rest/repository/ProductTransactionRepositoryTest.java
@@ -4,8 +4,8 @@ import eterea.migration.api.rest.configuration.EtereaMigrationConfiguration;
 import eterea.migration.api.rest.model.ProductTransaction;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 import java.util.Optional;

--- a/src/test/java/eterea/migration/api/rest/service/internal/FileServiceTest.java
+++ b/src/test/java/eterea/migration/api/rest/service/internal/FileServiceTest.java
@@ -33,6 +33,7 @@ class FileServiceTest {
         when(environment.getProperty("app.ftp-user")).thenReturn("testuser");
         when(environment.getProperty("app.ftp-password")).thenReturn("password");
         when(environment.getProperty("app.local-path")).thenReturn("/tmp/");
+        when(environment.getProperty("app.ftp-timeout")).thenReturn("5000");
 
         // This is the modern way to mock constructor calls with Mockito-inline
         try (MockedConstruction<JSch> mockedJsch = mockConstruction(JSch.class,
@@ -54,8 +55,8 @@ class FileServiceTest {
             Session sessionInstance = jschInstance.getSession("testuser", "localhost", 22);
             ChannelSftp channelInstance = (ChannelSftp) sessionInstance.openChannel("sftp");
 
-            verify(sessionInstance, times(1)).connect();
-            verify(channelInstance, times(1)).connect();
+            verify(sessionInstance, times(1)).connect(5000);
+            verify(channelInstance, times(1)).connect(5000);
             verify(channelInstance, times(1)).get(anyString(), anyString());
             verify(channelInstance, times(1)).exit();
             verify(sessionInstance, times(1)).disconnect();


### PR DESCRIPTION
## Descripción
This PR performs a major update to the project, upgrading to JDK 25 and Spring Boot 4.0.1. This includes necessary code changes, dependency updates, and configuration adjustments to ensure compatibility with the new versions.

## Cambios Realizados
- [x] Upgrade JDK from 24 to 25
- [x] Upgrade Spring Boot from 3.5.6 to 4.0.1
- [x] Update Spring Cloud to 2025.1.0
- [x] Update MySQL Connector to 9.5.0
- [x] Update SpringDoc OpenAPI to 3.0.1
- [x] Update commons-lang3 to 3.20.0
- [x] Refactor FileService: add SFTP timeout configuration and use @RequiredArgsConstructor
- [x] Change WordPressController scheduling from hourly to every 30 minutes
- [x] Update test annotations for Spring Boot 4 compatibility (@WebMvcTest, @MockitoBean, etc.)
- [x] Update CI/CD workflow and Dockerfile for JDK 25
- [x] Bump project version to 2.0.0

## Impacto Potencial
- [x] Requires JDK 25 in deployment environments
- [x] Spring Boot 4 introduces breaking changes in test annotations and configurations
- [x] May affect downstream services if API contracts change (though none apparent)

## Verificación
1. Checkout the branch: `git checkout 44-release-200-major-update-to-jdk-25-and-spring-boot-401`
2. Run tests: `mvn test`
3. Build the application: `mvn clean package`
4. Run the application locally and verify endpoints
5. Check logs for any deprecation warnings

## Notas Adicionales
This is a major version update (2.0.0) due to the Spring Boot major version change. Ensure all dependent services are compatible before deployment.

Closes #44